### PR TITLE
Fix padding problem.

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -21,3 +21,6 @@
 #project-files-container a {
 	padding-left: 9px;
 }
+.jstree-icon.file-icon{
+    left: 18px !important;
+}


### PR DESCRIPTION
After installing update 1.8, the file icons appear with the 'padding' problem. I applied a css adjustment to fix this.

![brakets icon request](https://cloud.githubusercontent.com/assets/910377/22517154/5de3d998-e88f-11e6-9bb3-cd0407957721.jpg)

